### PR TITLE
Fix for Sentry >= 8.0.0

### DIFF
--- a/src/sentry_notify_github_issues/plugin.py
+++ b/src/sentry_notify_github_issues/plugin.py
@@ -39,6 +39,9 @@ class NotifyGitHubIssuesPlugin(NotificationPlugin):
     conf_key = slug
     project_conf_form = NotifyGitHubIssuesForm
 
+    def is_configured(self, project):
+        return all((self.get_option(k, project) for k in ('repo', 'access_token')))
+
     def notify_users(self, group, event, fail_silently=False):
         repo = self.get_option('repo', group.project)
         api_endpoint = self.get_option('api_endpoint', group.project) or "https://api.github.com/"


### PR DESCRIPTION
Sentry 8.0.0 requires `is_configured`.
https://github.com/getsentry/sentry/releases/tag/8.0.0
